### PR TITLE
docs update: gradlew requires ./ to run

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,9 +38,9 @@ For more information about playing like hot keys or server hosting see the [dedi
 We have gone to great lengths to make developing and modding Terasology as easy as possible. We use Gradle to automate just about everything. As long as you have a [Java 8 SDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) running from source is a two step process:
 
 * Clone the code or download a zip
-* Run `./gradlew game` in the root of the project directory 
+* Run `gradlew game` (on Unixes, including Mac OS X, run `./gradlew` everywhere you see `gradlew`) in the root of the project directory 
 
-That's really it! If you want the project set up in IntelliJ (our favored IDE) you run `./gradlew idea` then load the generated project config. Then you get a bunch of run configurations and other stuff for free!
+That's really it! If you want the project set up in IntelliJ (our favored IDE) you run `gradlew idea` then load the generated project config. Then you get a bunch of run configurations and other stuff for free!
 
 For more on developing/modding see the [wiki](https://github.com/MovingBlocks/Terasology/wiki)
 

--- a/README.markdown
+++ b/README.markdown
@@ -38,9 +38,9 @@ For more information about playing like hot keys or server hosting see the [dedi
 We have gone to great lengths to make developing and modding Terasology as easy as possible. We use Gradle to automate just about everything. As long as you have a [Java 8 SDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) running from source is a two step process:
 
 * Clone the code or download a zip
-* Run `gradlew game` in the root of the project directory 
+* Run `./gradlew game` in the root of the project directory 
 
-That's really it! If you want the project set up in IntelliJ (our favored IDE) you run `gradlew idea` then load the generated project config. Then you get a bunch of run configurations and other stuff for free!
+That's really it! If you want the project set up in IntelliJ (our favored IDE) you run `./gradlew idea` then load the generated project config. Then you get a bunch of run configurations and other stuff for free!
 
 For more on developing/modding see the [wiki](https://github.com/MovingBlocks/Terasology/wiki)
 


### PR DESCRIPTION
### Contains

When attempting to run the directions in the README, I found that gradlew is a script in the repo, not a command that I should expect to find on my system, so I'm adding ./ to the doc to describe how to run it.

### How to test

Clone the repo and follow the instructions in the README.

